### PR TITLE
max players fixed

### DIFF
--- a/bot/cfg/cfg.py
+++ b/bot/cfg/cfg.py
@@ -133,3 +133,6 @@ mergedSubmissionsMenu_lineLength = 3
 cardContentFontSize = 90
 # Font size of smaller text to render on cards
 cardTitleFontSize = 40
+
+# Minimum number of players required to start a game
+minPlayerCount = 2

--- a/bot/game/sdbDeck.py
+++ b/bot/game/sdbDeck.py
@@ -90,9 +90,6 @@ class SDBDeck:
         self.emptyBlack = BlackCard("EMPTY", deckMeta["black_back"] if "black_back" in deckMeta else cfg.emptyBlackCard, 0, list(self.cards.values())[0])
         self.emptyWhite = WhiteCard("EMPTY", deckMeta["white_back"] if "white_back" in deckMeta else cfg.emptyWhiteCard, list(self.cards.values())[0])
 
-        whiteCount = deckMeta["white_count"] if "white_count" in deckMeta else sum(len(deckMeta["expansions"][expansion]["white"]) for expansion in deckMeta["expansions"] if "white" in deckMeta["expansions"][expansion])
-        self.maxPlayers = int(whiteCount / cfg.cardsPerHand)
-
 
     def randomWhite(self, expansions=[]):
         if expansions == []:

--- a/bot/reactionMenus/PagedReactionMenu.py
+++ b/bot/reactionMenus/PagedReactionMenu.py
@@ -136,22 +136,22 @@ class MultiPageOptionPicker(PagedReactionMenu):
     def __init__(self, msg : Message, pages : Dict[Embed, Dict[lib.emojis.BasedEmoji, ReactionMenu.NonSaveableSelecterMenuOption]] = {}, 
                     timeout : TimedTask.TimedTask = None, targetMember : Member = None, targetRole : Role = None, owningBasedUser : basedUser.BasedUser = None):
         
+        controls = {cfg.defaultEmojis.accept: ReactionMenu.NonSaveableReactionMenuOption("Submit", cfg.defaultEmojis.accept, self.delete, None),
+                    cfg.defaultEmojis.cancel: ReactionMenu.NonSaveableReactionMenuOption("Cancel Game", cfg.defaultEmojis.cancel, expiryFunctions.deleteReactionMenu, msg.id),
+                    cfg.defaultEmojis.spiral: ReactionMenu.NonSaveableReactionMenuOption("Toggle All", cfg.defaultEmojis.spiral,
+                                                                                                addFunc=ReactionMenu.selectorSelectAllOptions, addArgs=msg.id,
+                                                                                                removeFunc=ReactionMenu.selectorDeselectAllOptions, removeArgs=msg.id)
+        }
         self.selectedOptions = {}
         for pageOptions in pages.values():
             for option in pageOptions.values():
-                self.selectedOptions[option] = False
+                if option.emoji not in controls:
+                    self.selectedOptions[option] = False
 
         for pageEmbed in pages:
-            if cfg.defaultEmojis.accept not in pages[pageEmbed]:
-                pages[pageEmbed][cfg.defaultEmojis.accept] = ReactionMenu.NonSaveableReactionMenuOption("Submit", cfg.defaultEmojis.accept, self.delete, None)
-
-            if cfg.defaultEmojis.cancel not in pages[pageEmbed]:
-                pages[pageEmbed][cfg.defaultEmojis.cancel] = ReactionMenu.NonSaveableReactionMenuOption("Cancel Game", cfg.defaultEmojis.cancel, expiryFunctions.deleteReactionMenu, msg.id)
-
-            if cfg.defaultEmojis.spiral not in pages[pageEmbed]:
-                pages[pageEmbed][cfg.defaultEmojis.spiral] = ReactionMenu.NonSaveableReactionMenuOption("Toggle All", cfg.defaultEmojis.spiral,
-                                                                                                addFunc=ReactionMenu.selectorSelectAllOptions, addArgs=msg.id,
-                                                                                                removeFunc=ReactionMenu.selectorDeselectAllOptions, removeArgs=msg.id)
+            for controlEmoji in controls:
+                if controlEmoji not in pages[pageEmbed]:
+                    pages[pageEmbed][controlEmoji] = controls[controlEmoji]
 
         super().__init__(msg, pages=pages, timeout=timeout, targetMember=targetMember, targetRole=targetRole, owningBasedUser=owningBasedUser, noCancel=True)
 
@@ -164,9 +164,9 @@ class MultiPageOptionPicker(PagedReactionMenu):
             for fieldIndex in range(len(pageEmbed.fields)):
                 field = pageEmbed.fields[fieldIndex]
                 if field.name == "Currently selected:":
-                    pageEmbed.set_field_at(fieldIndex, name=field.name, value=newSelectedStr)
+                    pageEmbed.set_field_at(fieldIndex, name=field.name, value=newSelectedStr, inline=False)
                 break
-
+        
         await self.updateMessage(noRefreshOptions=True)
 
 

--- a/bot/reactionMenus/SDBExpansionsPicker.py
+++ b/bot/reactionMenus/SDBExpansionsPicker.py
@@ -1,0 +1,79 @@
+from bot.users import basedUser
+from discord import Message, Member, Role, Embed
+from typing import Dict, Tuple
+from . import ReactionMenu, PagedReactionMenu
+from .. import lib, botState
+from ..scheduling import TimedTask
+from ..users import basedUser
+from ..cfg import cfg
+
+
+async def cancelGame(menuID):
+    if menuID in botState.reactionMenusDB:
+        menu = botState.reactionMenusDB[menuID]
+        await menu.msg.channel.send("Game Cancelled.")
+        callingBGuild = botState.guildsDB.getGuild(menu.msg.guild.id)
+        if menu.msg.channel in callingBGuild.runningGames:
+            del callingBGuild.runningGames[menu.msg.channel]
+        await menu.msg.delete()
+        del botState.reactionMenusDB[menuID]
+
+
+class SDBExpansionsPicker(PagedReactionMenu.MultiPageOptionPicker):
+    def __init__(self, msg: Message, expansionNamesCardCounts: Dict[str, Tuple[int, int]], timeout: TimedTask.TimedTask = None, targetMember: Member = None, targetRole: Role = None, owningBasedUser: basedUser.BasedUser = None):
+        numExpansions = len(expansionNamesCardCounts)
+        expansionNames = list(expansionNamesCardCounts.keys())
+        self.currentMaxPlayers = 0
+        self.hasBlackCardsSelected = False
+        self.expansionNamesCardCounts = expansionNamesCardCounts
+
+        optionPages = {}
+        embedKeys = []
+        numPages = numExpansions // 5 + (0 if numExpansions % 5 == 0 else 1)
+        
+        for pageNum in range(numPages):
+            embedKeys.append(lib.discordUtil.makeEmbed(titleTxt="Select Expansion Packs", desc="Which expansions would you like to use?",
+                                                        footerTxt="Page " + str(pageNum + 1) + " of " + str(numPages) + \
+                                                            " | This menu will expire in " + lib.timeUtil.td_format_noYM(timeout.expiryDelta)))
+            embedKeys[-1].add_field(name="Currently selected:", value="​", inline=False)
+            embedKeys[-1].add_field(name="Max players:", value="0", inline=False)
+            optionPages[embedKeys[-1]] = {}
+
+        for expansionNum in range(numExpansions):
+            pageNum = expansionNum // 5
+            pageEmbed = embedKeys[pageNum]
+            optionEmoji = cfg.defaultEmojis.menuOptions[expansionNum % 5]
+            expansionName = expansionNames[expansionNum]
+            pageEmbed.add_field(name=optionEmoji.sendable + " : " + expansionName, value="`" + str(expansionNamesCardCounts[expansionName][0]) + " white cards | " + str(expansionNamesCardCounts[expansionName][1]) + " black cards`", inline=False)
+            optionPages[pageEmbed][optionEmoji] = ReactionMenu.NonSaveableSelecterMenuOption(expansionName, optionEmoji, msg.id)
+
+        for page in embedKeys:
+            page.add_field(name=cfg.defaultEmojis.accept.sendable + " : Submit", value="​", inline=False)
+            page.add_field(name=cfg.defaultEmojis.cancel.sendable + " : Cancel", value="​", inline=False)
+            page.add_field(name=cfg.defaultEmojis.spiral.sendable + " : Toggle all", value="​", inline=False)
+            optionPages[page][cfg.defaultEmojis.cancel] = ReactionMenu.NonSaveableReactionMenuOption("Cancel", cfg.defaultEmojis.cancel, addFunc=cancelGame, addArgs=msg.id)
+
+        super().__init__(msg, pages=optionPages, timeout=timeout, targetMember=targetMember, targetRole=targetRole, owningBasedUser=owningBasedUser)
+
+
+    async def updateSelectionsField(self):
+        self.currentMaxPlayers = 0
+        for option in self.selectedOptions:
+            if self.selectedOptions[option]:
+                self.currentMaxPlayers += self.expansionNamesCardCounts[option.name][0]
+                if not self.hasBlackCardsSelected and self.expansionNamesCardCounts[option.name][1] > 0:
+                    self.hasBlackCardsSelected = True
+                
+        self.currentMaxPlayers = self.currentMaxPlayers // cfg.cardsPerHand
+
+        for pageEmbed in self.pages:
+            pageEmbed.set_field_at(1, name=pageEmbed.fields[1].name, value=str(self.currentMaxPlayers), inline=False)
+        
+        # for pageEmbed in self.pages:
+        #     for fieldIndex in range(len(pageEmbed.fields)):
+        #         field = pageEmbed.fields[fieldIndex]
+        #         if field.name == "Max players:":
+        #             pageEmbed.set_field_at(fieldIndex, name=field.name, value=str(self.currentMaxPlayers))
+        #         break
+
+        await super().updateSelectionsField()

--- a/bot/reactionMenus/SDBSignupMenu.py
+++ b/bot/reactionMenus/SDBSignupMenu.py
@@ -34,7 +34,7 @@ class SDBSignupMenu(ReactionMenu.ReactionMenu):
         super().__init__(msg, options = options,
                     titleTxt = game.owner.display_name + " is playing Super Deck Breaker!",
                     desc = "Deck: " + game.deck.name +
-                        "\nMax players: " + str(game.deck.maxPlayers) +
+                        "\nMax players: " + str(game.maxPlayers) +
                         "\nRounds: " + (("Best of " + str(game.rounds)) if game.rounds != -1 else "Free play") +
                         "\nExpansions: " + ", ".join(game.expansionNames) +
                         "\n\nGame beginning in " + lib.timeUtil.td_format_noYM(timeToJoin) + "!",
@@ -49,7 +49,7 @@ class SDBSignupMenu(ReactionMenu.ReactionMenu):
         sendChannel = reactingUser.dm_channel
         
         try:
-            if self.numSignups == self.game.deck.maxPlayers:
+            if self.numSignups == self.game.maxPlayers:
                 await sendChannel.send("This game is full!")
                 try:
                     await self.msg.remove_reaction(cfg.defaultEmojis.accept.sendable, reactingUser)
@@ -83,7 +83,7 @@ class SDBSignupMenu(ReactionMenu.ReactionMenu):
     async def endSignups(self):
         self.msg = await self.msg.channel.fetch_message(self.msg.id)
         reaction = [reaction for reaction in self.msg.reactions if lib.emojis.BasedEmoji.fromReaction(reaction.emoji) == cfg.defaultEmojis.accept]
-        if not reaction or self.numSignups < 2:
+        if not reaction or self.numSignups < cfg.minPlayerCount:
             await self.msg.channel.send(":x: " + self.game.owner.mention + " Game cancelled: Not enough players joined the game.")
             await expiryFunctions.deleteReactionMenu(self.msg.id)
         else:


### PR DESCRIPTION
fix being able to start a game without enough cards. Add card counts and current max players to expansions picker menu. Handle max players on a per-game basis rather than per-deck. Fix MultiPageOptionPickers adding controls to selectedOptions